### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "csharp"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
-# BabyYoda
-A twitch integrated baby yoda that you can interact with
+[![Run on Repl.it](https://repl.it/badge/github/zerratar/BabyYoda)](https://repl.it/github/zerratar/BabyYoda)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@hcahoon01/BabyYoda-1).